### PR TITLE
chore(ci): update workflows for stricter auth and Bedrock integration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,9 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@claude'))
+       contains(github.event.comment.body, '@claude') &&
+       (github.actor == github.repository_owner ||
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)))
 
     runs-on: ubuntu-latest
     permissions:
@@ -25,23 +27,42 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    env:
+      AWS_REGION: us-west-2
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.event.pull_request.merge_commit_sha }}
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta
+        env:
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: 8192
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_bedrock: "true"
+          model: "us.anthropic.claude-sonnet-4-20250514-v1:0"
+          github_token: ${{ steps.app-token.outputs.token }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Optional: Specify different Bedrock model (uncomment for Claude Opus 4)
+          # model: "us.anthropic.claude-opus-4-20250514-v1:0"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,30 +13,59 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      ) && (
+        github.actor == github.repository_owner ||
+        (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
+    env:
+      AWS_REGION: us-west-2
+
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta
+        env:
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: 8192
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_bedrock: "true"
+          model: "us.anthropic.claude-sonnet-4-20250514-v1:0"
+          github_token: ${{ steps.app-token.outputs.token }}
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Optional: Specify different Bedrock model (uncomment for Claude Opus 4)
+          # model: "us.anthropic.claude-opus-4-20250514-v1:0"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: |
-            type=gha,mode=max
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   release:
     name: Create GitHub Release

--- a/claude.sh
+++ b/claude.sh
@@ -4,7 +4,7 @@ set -e
 # Claude Starter Script with Docker Support
 # Runs Claude Code CLI locally or in a Docker container for safe execution
 
-VERSION="0.2.2"
+VERSION="0.2.5"
 DOCKER_IMAGE="${DOCKER_IMAGE:-ghcr.io/lroolle/claude-code-yolo}"
 DOCKER_TAG="${DOCKER_TAG:-latest}"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,6 +92,7 @@ setup_nonroot_user() {
     # Make /root fully accessible - Claude needs permissions to work
     chmod 755 /root 2>/dev/null || true
 
+    # TODO: claude does support CLAUDE_CONFIG_DIR
     # Essential: Handle .claude directory
     if [ -d "/root/.claude" ]; then
         [ "$VERBOSE" = "true" ] && echo "[entrypoint] linking .claude"
@@ -111,7 +112,6 @@ setup_nonroot_user() {
         [ "$VERBOSE" = "true" ] && echo "[entrypoint] linking .config/gcloud"
         mkdir -p "$CLAUDE_HOME/.config"
         chmod -R 755 /root/.config/gcloud 2>/dev/null || true
-        ln -sfn /root/.config/gcloud "$CLAUDE_HOME/.config/gcloud"
     fi
 
     # Common: AWS credentials
@@ -128,7 +128,7 @@ setup_nonroot_user() {
         if [ -e "$item" ] && [ "$item" != "/root/." ] && [ "$item" != "/root/.." ]; then
             basename_item=$(basename "$item")
             case "$basename_item" in
-            .claude | .aws | .config)
+            .claude | .aws )
                 continue
                 ;;
             *)


### PR DESCRIPTION
- Restrict Claude triggers to repo owners, members, collaborators
- Switch Claude actions to use Bedrock and Sonnet 4 via AWS OIDC
- Add GitHub App token generation for secure checkout and API calls
- Simplify Docker build cache config in release workflow
- Add note on CLAUDE_CONFIG_DIR and fix gcloud config symlink in entrypoint